### PR TITLE
kernel driver setup bugfix

### DIFF
--- a/wacom_serial5.c
+++ b/wacom_serial5.c
@@ -623,6 +623,7 @@ static int send_setup_string(struct wacom *wacom, struct serio *serio)
 			COMMAND_ID
 			COMMAND_TRANSMIT_AT_MAX_RATE
 			COMMAND_START_SENDING_PACKETS;
+		break;
 	default:
 		/* TODO: remove this all together? All protocol5 tablets 
 		 * seem to use the string above.*/


### PR DESCRIPTION
I have an Intuos2 on Ubuntu 12.04. After loading the kernel driver and starting inputattach, I got following error:

[ 1428.074463] serio: Serial port ttyUSB0
[ 1428.090580] input (null): Model string: ~#XD-0912-R00,V1.2-6
[ 1428.090589] input (null): Wacom tablet: Intuos2, version 1.2
[ 1428.101941] input (null): Coordinates string: ~C30480,24060
[ 1428.101983] wacom_serial5: probe of serio5 failed with error -1

With this fix the code works fine for me.

Thanks for this project!
